### PR TITLE
Fixed dumper for Windows platform & updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # hostnet/webpack-bridge
 
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Quick how-to](#quick-how-to)
+- [Configuration](#configuration)
+  - [Node](#node)
+    - [Multi-platform configuration](#multi-platform-configuration)
+  - [Bundle configuration](#bundle-configuration)
+  - [Shared dependencies](#shared-dependencies)
+  - [Asset output directories](#asset-output-directories)
+- [Loaders](#loaders)
+  - [CSS](#css)
+  - [Less](#less)
+  - [URL](#url)
+- [Plugins](#plugins)
+
+## Introduction
+
 This package assumes you already have some basic knowledge about webpack; what it is and what it does for you. If this is not the case, please [read this first](http://webpack.github.io/docs/motivation.html). It will only take a minute, but it's worth it.
 
 Instead of having all bundle-specific assets in one location, this package handles assets from __two__ different locations. The reasoning behind this decision is because webpack assets are compiled on the server and shouldn't be accessible from the browser.
@@ -9,18 +26,12 @@ Instead of having all bundle-specific assets in one location, this package handl
 
 Both of these directories are being watched when running in _debug mode_. When an asset has been added, modified or deleted, compiled sources are updated directly.
 
-- [hostnet/webpack-bridge](#hostnetwebpack-bridge)
-  - [Installation](#installation)
-  - [Quick how-to](#quick-how-to)
-  - [Configuration](#configuration)
-    - [Node](#node)
-      - [Multi-platform configuration](#multi-platform-configuration)
-    - [Bundle configuration](#bundle-configuration)
-    - [Shared dependencies](#shared-dependencies)
-    - [Asset output directories](#asset-output-directories)
-  - [Loaders](#loaders)
-    - [Less](#less)
-    - [URL](#url)
+The package comes with two _twig functions_:
+
+ - `webpack_asset(url)` : Resolves compiled asset files. E.g.: `webpack_asset('@AppBundle/app.js')` resolves to `Resources/assets/app.js` in AppBundle.
+ - `webpack_public(url)`: Resolves dumped public assets from the `Resources/public` directory. Bundle referencing works the same way as in `webpack_asset`.
+
+Please note that `webpack_asset` returns an array with two keys: `js` and `css`. More info on this in the [Quick how-to](#quick-how-to) example.
 
 ## Installation
 
@@ -34,7 +45,9 @@ Once installed, enable the bundle `Hostnet\Bundle\WebpackBridge\WebpackBridgeBun
 
 ## Quick how-to
 
-> ___Warning___: the package assumes by default that `node` and `webpack` plus any additional modules are pre-installed on your system. If this is not the case, you need to specify some configuration in your `config.yml` file after enabling the bundle.
+> ___Warning___: the package assumes by default that `node` and `webpack` plus any additional modules are pre-installed
+> on your system. If this is not the case, you need to specify some configuration in your `config.yml` file after
+> enabling the bundle. See [Node Configuration](#node) for more details.
 
 Imagine having the following files in your application:
  - `src/AppBundle/Resources/assets/app.js`
@@ -45,23 +58,41 @@ Imagine having the following files in your application:
 Lets start with the twig template.
 ```twig
 {# src/AppBundle/Resources/views/base.html.twig #}
-<script src="{{ webpack_asset("@AppBundle/app.js").js }}"></script>
-```
-Use the twig function `webpack_asset(url)` in your template to specify an [entry-point](http://webpack.github.io/docs/configuration.html#entry).
-In short, an entry-point is an asset that will be compiled and exported to the output path. This path defaults to
-`%kernel.root_dir%/../web`. The compiled file will be named `app_bundle.app.js` by default. Both of these settings are configurable.
 
-`webpack_asset` returns an array with two keys: `js` referencing the compiled javascript file and `css` referencing the compiled css file.
-Beware that the `css` element may be blank if this file doesn't exist.
+The quick variant:
+<script src="webpack_asset('@AppBundle/app.js').js"></script>
+
+The more maintainable variant: Store the result to a variable for easy access.
+{% set asset = webpack_asset('@AppBundle/app.js') %}
+
+<script src="{{ asset.js }}"></script>
+{% if asset.css is not empty %}
+    <link rel="stylesheet" href="{{ asset.css }}">
+{% endif %}
+```
+
+Use the twig function `webpack_asset(url)` in your template to specify an 
+[entry-point](http://webpack.github.io/docs/configuration.html#entry). In short, an entry-point is an asset that will be
+compiled and exported to the output path. This path defaults to `%kernel.root_dir%/../web`. The compiled file will be
+named `app_bundle.app.js` by default. Both of these settings are configurable.
+
+`webpack_asset` returns an array with two keys: `js` referencing the compiled javascript file and `css` referencing the
+compiled css file. Beware that the `css` element may be blank if this file doesn't exist. The latter would occur if the
+referenced javascript file - or its dependencies - doesn't include any CSS-type files.
 
 ```javascript
 // src/AppBundle/Resources/assets/app.js
 var image = require('@AppBundle/image.js');
 document.write(image('/bundles/app/images/logo.png'));
 ```
-Any webpack asset may use the `require` or `define` functions that come with webpack. Webpack allows for both CommonJS and AMD-style loading of files. As you might have noticed, the example above references a bundle by its shorthand name, `@AppBundle`. The bridge automatically aliasses tracked bundles for you, so you're free to use this method of referencing dependencies throughout the entire application.
+Any webpack asset may use the `require` or `define` functions that come with webpack. Webpack allows for both CommonJS
+and AMD-style loading of files. As you might have noticed, the example above references a bundle by its shorthand name,
+`@AppBundle`. The bridge automatically aliases tracked bundles for you, so you're free to use this method of
+referencing dependencies throughout the entire application.
 
-The `logo.png` file, located in the `Resources/public` directory will be symlinked or copied to `/web/bundles/<lowercased_bundle_name>` automatically. You should place any file that does not need processing in the public directory to avoid unnecessary load times in debug mode (app_dev).
+The `logo.png` file, located in the `Resources/public` directory will be symlinked or copied to
+`/web/bundles/<lowercased_bundle_name>` automatically. You should place any file that does not need processing in the
+public directory to avoid unnecessary load times in debug mode (app_dev).
 
 Here is a simple image module that returns an image HTML-tag as string.
 ```javascript
@@ -75,7 +106,8 @@ module.exports = function (src) {
 
 The configuration options of this package are pretty large, but all settings are optional and come with sane defaults.
 
-The following configuration options are directly copied from webpack itself and can be configured as such. The only difference to take into consideration is that keys are written in __underscores rathar than camelCase__.
+The following configuration options are directly copied from webpack itself and can be configured as such. The only
+difference to take into consideration is that keys are written in __underscores rather than camelCase__.
 
 For example, in webpack configuring the `output.publicPath` setting would be written as:
 ```yaml
@@ -89,11 +121,14 @@ The following "webpack" sections are configurable through `config.yml`:
  - `resolve`: http://webpack.github.io/docs/configuration.html#resolve
  - `resolve_loader`: http://webpack.github.io/docs/configuration.html#resolveloader
 
-The options `entry`, `resolve.root`, `resolve.alias` and `resolveModule.modulesDirectories` are configured automatically based on split points (entry points), tracked bundles and the specified (or detected) node_modules directory. If you specify any of these options, their values will be appended to the generated values.
+The options `entry`, `resolve.root`, `resolve.alias` and `resolveModule.modulesDirectories` are configured automatically
+based on split points (entry points), tracked bundles and the specified (or detected) node_modules directory. If you
+specify any of these options, their values will be appended to the generated values.
 
 ### Node
 
-In order for this package to work properly, it needs to know the location where nodejs is installed and where to find its node_modules directory. If node is installed globally on your server, this setting may be omitted.
+In order for this package to work properly, it needs to know the location where nodejs is installed and where to find
+its node_modules directory. If node is installed globally on your server, this setting may be omitted.
 
 ```yaml
 # config.yml
@@ -105,7 +140,9 @@ webpack:
 
 #### Multi-platform configuration
 
-Since your application might be running on both windows, linux and macs all at the same time, you might need to specify different node binaries. If this is the case, instead of passing a string referencing the node binary to the `node.binary` option, you may pass an array:
+Since your application might be running on both windows, linux and macs all at the same time, you might need to specify
+different node binaries. If this is the case, instead of passing a string referencing the node binary to the
+`node.binary` option, you may pass an array:
 
 ```yaml
 webpack:
@@ -119,18 +156,22 @@ webpack:
           fallback: '/if/os/detection/fails/path/to/node'
 ```
 
-Again, all settings are optional. If a key isn't specified, it defaults to "node". This will only work if node is installed globally.
+Again, all settings are optional. If a key isn't specified, it defaults to "node". This will only work if node is
+installed globally.
 
 ### Bundle configuration
 
-By default, all enabled bundles are tracked. However, you may explicitly specify a set of bundles to track for performance or security reasons.
+By default, all enabled bundles are tracked. However, you may explicitly specify a set of bundles to track for
+performance or security reasons.
 
 ```yaml
 webpack:
     bundles: ['AppBundle', 'YourBundle']
 ```
 
-As previously mentioned, assets are located in two directories: `assets` and `public`. These options are configurable, but it's ___strongly recommended to leave this as is___. Vendor packages might not be aware of your custom configuration which results in not being able to resolve assets.
+As previously mentioned, assets are located in two directories: `assets` and `public`. These options are configurable,
+but it's ___strongly recommended to leave this as is___. Vendor packages might not be aware of your custom configuration
+which results in not being able to resolve assets.
 
 ```yaml
 webpack:
@@ -155,7 +196,7 @@ webpack:
 
 - Dumped assets from the "public" directory are symlinked or copied to the `<output.path>/<output.dump_dir>` directory.
 - Compiled assets from the "assets" directory are written to the `<output.path>` directory.
-- The twig function `webpack_asset` returns compiled filenames prefixed with the `<output.public_path>` directory.
+- The twig function `webpack_asset` returns compiled file names prefixed with the `<output.public_path>` directory.
 
 ```yaml
 webpack:
@@ -165,9 +206,11 @@ webpack:
         public_path: '/'
 ```
 
-The `public_path` value represents the asset paths from a client-side perspecive. Therefore, it must specify a path that exists inside the DOCUMENT_ROOT directory.
+The `public_path` value represents the asset paths from a client-side perspective. Therefore, it must specify a path
+that exists inside the DOCUMENT_ROOT directory.
 
-For example, if the `output.path` value is `%kernel.root_dir/../web/packed`, the value of `output.public_path` must be set to `/packed`.
+For example, if the `output.path` value is `%kernel.root_dir/../web/packed`, the value of `output.public_path` must be
+set to `/packed`.
 
 ## Loaders
 
@@ -176,23 +219,26 @@ Loaders allow you to `require` files other than javascript. This package comes w
  - `CSSLoader` : include CSS files
  - `UrlLoader` : include images (converted to base64)
  - `LessLoader`: include less files.
+
+Each loader has its own configuration under the `loaders` section.
+
+### CSS
+
+Enables loading CSS files.
+
+```yaml
+webpack:
+    loaders:
+        css:
+            enabled: true
+            filename: '[name].css'
+            all_chunks: true
+```
  
- Each loder has its own configuration under the `loaders` section.
- 
- ### CSS
- 
- Enables loading CSS files.
- 
- ```yaml
- webpack:
-     loaders:
-         css:
-             enabled: true
-             filename: '[name].css'
-             all_chunks: true
- ```
- 
-If `filename` and `all_chunks` are omitted, any CSS is converted to a style-tag in the document rather than being exported to a separate CSS file. If the `output.common_id` setting is specified - which allows extracting shared code - the [CommonsChunkPlugin]() will be used automatically as well.
+If `filename` and `all_chunks` are omitted, any CSS is converted to a style-tag in the document rather than being
+exported to a separate CSS file. If the `output.common_id` setting is specified - which allows extracting shared code -
+the [CommonsChunkPlugin](http://webpack.github.io/docs/list-of-plugins.html#commonschunkplugin) will be used
+automatically as well.
 
 Depending on the specified configuration, one or more node-modules are required:
 
@@ -225,3 +271,47 @@ webpack:
        less:
            enabled: true
 ```
+
+## Plugins
+
+The webpack-bridge package comes with an easy way to develop and use plugins. A plugin simply writes pieces of code
+to the generated webpack configuration file, and by doing so it _should_ enable more features.
+
+### DefinePlugin
+
+The define plugin allows you to declare global variables throughout the application.
+See the [defineplugin documentation](https://github.com/webpack/docs/wiki/list-of-plugins#defineplugin) for more
+information.
+
+In the example below, imagine a parameter named "environment" having the value "dev".
+```yaml
+webpack:
+    plugins:
+        constants:
+            ENVIRONMENT: %environment%
+```
+
+Later, somewhere in an asset...
+```javascript
+// start
+if (ENVIRONMENT === 'dev') {
+    console.log('Hello World!');
+}
+// end
+```
+These variable declarations are parsed by webpack. Once the code is compiled and minified, these variables are left out
+completely in the final code.
+
+This means that the code on your development machine would result in something like this: 
+```javascript
+// start
+console.log('Hello World');
+// end
+```
+
+And in production
+```javascript
+// start
+// end
+```
+Note that the comments are only here for illustrating this example. Compiled and minified code won't contain these.

--- a/src/Component/Asset/Dumper.php
+++ b/src/Component/Asset/Dumper.php
@@ -60,20 +60,10 @@ class Dumper
             $fs->mkdir($this->output_dir, 0775);
         }
 
-        // Create symlinks or fall back to hard-copy.
-        if (! $fs->exists($target_dir)) {
-            try {
-                $fs->symlink($path, $target_dir);
-                $this->logger->info(sprintf('Created symlink: %s <=> %s', $path, $target_dir));
-            } catch (IOException $e) {
-                $this->logger->warning($e->getMessage() . ' Falling back to hard-copy.');
-                $fs->mkdir($target_dir);
-            }
-        }
-
-        if (! is_link($target_dir)) {
-            $fs->mirror($path, $target_dir, null, ['override' => true, 'copy_on_windows' => true, 'delete' => true]);
-        }
+        // Copy on Windows must be set to true for safety reasons. Although symlinks are supported, they become hard-
+        // links instead of soft-links. This means that removing a symlink would essentially also remove any and all
+        // files from the source path.
+        $fs->mirror($path, $target_dir, null, ['override' => true, 'copy_on_windows' => true, 'delete' => true]);
     }
 
     /**

--- a/src/Component/Configuration/Config/OutputConfig.php
+++ b/src/Component/Configuration/Config/OutputConfig.php
@@ -31,7 +31,7 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
                     ->scalarNode('path')->defaultValue('%kernel.root_dir%/../web')->end()
                     ->scalarNode('dump_path')->defaultValue('%kernel.root_dir%/../web/bundles')->end()
                     ->scalarNode('filename')->defaultValue('[name].js')->end()
-                    ->scalarNode('common_id')->defaultValue('common.js')->end()
+                    ->scalarNode('common_id')->defaultValue('common')->end()
                     ->scalarNode('chunk_filename')->defaultValue('[name].[hash].chunk.js')->end()
                     ->scalarNode('source_map_filename')->defaultValue('[file].sourcemap.js')->end()
                     ->scalarNode('devtool_module_filename_template')->defaultValue('webpack:///[resource-path]')->end()


### PR DESCRIPTION
Symlinks created in windows behave dangerously. There is also a bug in symfony's Filesystem component making matters worse.

When a symlink is created, Filesystem::mirror() doesn't take this fact into consideration but simply starts copying files from source to destination (while dest. is a symlnk). This results in symfony completely obliterating the contents of all files.

Also, when removing a symlinked directory, all files in the source directory are suddenly removed.

This patch forces the "copy_on_windows" flag in the asset dumper.