### PR TITLE
Added XML namespace

### DIFF
--- a/src/Bundle/DependencyInjection/WebpackExtension.php
+++ b/src/Bundle/DependencyInjection/WebpackExtension.php
@@ -78,4 +78,10 @@ class WebpackExtension extends Extension
 
         return 'fallback';
     }
+    
+    /** {@inheritdoc} */
+    public function getNamespace()
+    {
+        return 'http://hostnet.nl/schema/dic/webpack';
+    }
 }


### PR DESCRIPTION
Without this, XML configuration uses the default `http://example.org/schema/dic/hostnet_webpack` namespace